### PR TITLE
refactor: improve response handling and simplify configuration parsing

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -62,7 +62,7 @@ func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (r *dns.Msg, er
 	if resp, err = c.client.Do(req); err != nil {
 		return
 	}
-	defer resp.Body.Close()
+	defer dumpRemainingResponse(resp)
 
 	// RFC8484 Section 4.2.1:
 	// A successful HTTP response with a 2xx status code is used for any valid DNS response,
@@ -85,6 +85,13 @@ func (c *dohDNSClient) Query(ctx context.Context, dnsreq []byte) (r *dns.Msg, er
 	r = new(dns.Msg)
 	err = r.Unpack(body)
 	return
+}
+
+func dumpRemainingResponse(res *http.Response) {
+	if res != nil {
+		_, _ = io.Copy(io.Discard, res.Body)
+		res.Body.Close()
+	}
 }
 
 type metricDNSClient struct {


### PR DESCRIPTION
This pull request focuses on improving the `proxy.go` and `setup.go` files by refactoring the code for better readability and maintainability. The most important changes include adding a new function to handle response body cleanup, refactoring the setup of the HTTP client, and improving the configuration parsing logic.

### Enhancements to response handling:

* [`proxy.go`](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L65-R65): Added a new function `dumpRemainingResponse` to handle the cleanup of the response body, improving the readability and maintainability of the `Query` method. [[1]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499L65-R65) [[2]](diffhunk://#diff-fd4820e2c415e0057b0e67d294303bdde3b98c2731b6dbd1e2b0f79349744499R90-R96)

### Refactoring of HTTP client setup:

* [`setup.go`](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL36-R41): Refactored the setup of the HTTP client by directly initializing it with the transport configuration, simplifying the code.

### Improvements to configuration parsing:

* [`setup.go`](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL67-L94): Simplified the `parseConfig` function by removing redundant error checks and consolidating the parsing of `toURLs` into a new helper function `parseToURLs`. [[1]](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL67-L94) [[2]](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL112-R121)
* [`setup.go`](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL129-R144): Refactored the `parseBlock` and `parseExcept` functions to improve error handling and code clarity. [[1]](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL129-R144) [[2]](diffhunk://#diff-cf9a198b7e09fd9e99707c1ca07ebaf64974ed4132d695cec2ac472270c1fa9eL152-R156)